### PR TITLE
Create eslint config for ts react

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,45 +1,49 @@
-import js from '@eslint/js';
-import react from 'eslint-plugin-react';
 import tseslint from 'typescript-eslint';
+import pluginReact from 'eslint-plugin-react';
+import js from '@eslint/js';
 
 export default [
+  { ignores: ['node_modules/**', '.next/**', 'public/**', '_backup_root_dupes/**'] },
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
   {
-    ignores: [
-      '.next/**',
-      'node_modules/**',
-      'dist/**',
-      '*.config.js',
-      '*.config.ts',
-    ],
-    plugins: {
-      react,
-    },
-    settings: {
-      react: {
-        version: 'detect',
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        ecmaVersion: 2023,
+        sourceType: 'module',
+      },
+      globals: {
+        JSX: 'readonly',
+        React: 'readonly',
+        window: 'readonly',
+        document: 'readonly',
+        navigator: 'readonly',
       },
     },
+    plugins: {
+      react: pluginReact,
+    },
+    settings: {
+      react: { version: 'detect' }, // для предупреждения плагина
+    },
     rules: {
-      // React
+      // React 17+ / 19 — новая трансформация JSX, импорта React не требуется
       'react/react-in-jsx-scope': 'off',
 
-      // TypeScript
-      '@typescript-eslint/no-explicit-any': 'off',
+      // В R3F часто используем нестандартные пропы на JSX-примитивах
+      'react/no-unknown-property': 'off',
+
+      // Чуть смягчённые правила, чтобы не мешали разработке
       '@typescript-eslint/no-unused-vars': [
         'warn',
-        {
-          vars: 'all',
-          args: 'after-used',
-          ignoreRestSiblings: true,
-        },
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
-      '@typescript-eslint/no-this-alias': 'off',
-
-      // Base JS
+      '@typescript-eslint/no-explicit-any': 'off', // временно, пока MVP
+      '@typescript-eslint/consistent-type-imports': 'warn',
+      'no-case-declarations': 'warn',
       'no-prototype-builtins': 'off',
-      'no-undef': 'off',
     },
   },
 ];


### PR DESCRIPTION
Add a modern ESLint configuration for TypeScript and React projects, including type-checked rules and specific adjustments for React 17+/19 and R3F.

This configuration sets up recommended type-checked rules, disables `react-in-jsx-scope` for React 17+/19's new JSX transform, and turns off `no-unknown-property` to support custom props often used in React Three Fiber (R3F). It also includes relaxed rules for development, such as warning on unused variables (ignoring `_` prefixed ones) and allowing `any` for MVP stages.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7882ebf-b20d-4002-9c5f-eb9277c21616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7882ebf-b20d-4002-9c5f-eb9277c21616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

